### PR TITLE
Add &service=github to the coverage badge link to make it not cache randomly

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Branch  | Travis CI  | Code Coverage |
 ------- | ---------- | ------------- |
 master  | [![Build Status](https://travis-ci.org/hpi-swa-teaching/AcceptIt.svg?branch=master)](https://travis-ci.org/hpi-swa-teaching/AcceptIt) | |
-develop | [![Build Status](https://travis-ci.org/hpi-swa-teaching/AcceptIt.svg?branch=develop)](https://travis-ci.org/hpi-swa-teaching/AcceptIt) | [![Coverage Status](https://coveralls.io/repos/github/hpi-swa-teaching/AcceptIt/badge.svg?branch=develop)](https://coveralls.io/github/hpi-swa-teaching/AcceptIt) |
+develop | [![Build Status](https://travis-ci.org/hpi-swa-teaching/AcceptIt.svg?branch=develop)](https://travis-ci.org/hpi-swa-teaching/AcceptIt) | [![Coverage Status](https://coveralls.io/repos/github/hpi-swa-teaching/AcceptIt/badge.svg?branch=develop&service=github)](https://coveralls.io/github/hpi-swa-teaching/AcceptIt) |
 
 # Installation  
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Branch  | Travis CI  | Code Coverage |
 ------- | ---------- | ------------- |
 master  | [![Build Status](https://travis-ci.org/hpi-swa-teaching/AcceptIt.svg?branch=master)](https://travis-ci.org/hpi-swa-teaching/AcceptIt) | |
-develop | [![Build Status](https://travis-ci.org/hpi-swa-teaching/AcceptIt.svg?branch=develop)](https://travis-ci.org/hpi-swa-teaching/AcceptIt) | [![Coverage Status](https://coveralls.io/repos/github/hpi-swa-teaching/AcceptIt/badge.svg?branch=develop&service=github)](https://coveralls.io/github/hpi-swa-teaching/AcceptIt) |
+develop | [![Build Status](https://travis-ci.org/hpi-swa-teaching/AcceptIt.svg?branch=develop)](https://travis-ci.org/hpi-swa-teaching/AcceptIt) | [![Coverage Status](http://coveralls.io/repos/github/hpi-swa-teaching/AcceptIt/badge.svg?branch=develop)](https://coveralls.io/github/hpi-swa-teaching/AcceptIt) |
 
 # Installation  
 


### PR DESCRIPTION
This should fix our coveralls badge according to this issue comment: https://github.com/lemurheavy/coveralls-public/issues/971#issuecomment-338942441

and it seems to do so for me.